### PR TITLE
Filtrering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,15 @@ jobs:
         uses: actions/checkout@master
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v1
+      - name: Setup gradle dependency cache
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.*gradle*') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
+            ${{ runner.os }}-gradle-
       - name: Run tests
         env:
           ORG_GRADLE_PROJECT_githubUser: x-access-token

--- a/.github/workflows/devdeploy.yml
+++ b/.github/workflows/devdeploy.yml
@@ -20,18 +20,15 @@ jobs:
         uses: actions/checkout@master
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v1
+      - name: Setup gradle dependency cache
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.*gradle*') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
+            ${{ runner.os }}-gradle-
       - name: Run tests
         env:
           ORG_GRADLE_PROJECT_githubUser: x-access-token

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -3,26 +3,37 @@ package no.nav.syfo.aktivermelding.db
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 import no.nav.syfo.application.db.DatabaseInterface
 import no.nav.syfo.application.db.toList
 
-fun DatabaseInterface.hentPlanlagteMeldingerSomSkalAktiveres(now: OffsetDateTime): List<UUID> {
+fun DatabaseInterface.hentPlanlagteMeldingerSomSkalAktiveres(now: OffsetDateTime): List<PlanlagtMeldingDbModel> {
     connection.use { connection ->
         return connection.hentPlanlagtMelding(now)
     }
 }
 
-fun Connection.hentPlanlagtMelding(now: OffsetDateTime): List<UUID> =
+fun Connection.hentPlanlagtMelding(now: OffsetDateTime): List<PlanlagtMeldingDbModel> =
     this.prepareStatement(
         """
-            SELECT id FROM planlagt_melding WHERE sendes<? AND sendt is null and avbrutt is null;
+            SELECT * FROM planlagt_melding WHERE sendes<? AND sendt is null and avbrutt is null;
             """
     ).use {
         it.setTimestamp(1, Timestamp.from(now.toInstant()))
-        it.executeQuery().toList { toUuid() }
+        it.executeQuery().toList { toPlanlagtMeldingDbModel() }
     }
 
-fun ResultSet.toUuid(): UUID =
-    getObject("id", UUID::class.java)
+fun ResultSet.toPlanlagtMeldingDbModel(): PlanlagtMeldingDbModel =
+    PlanlagtMeldingDbModel(
+        id = getObject("id", UUID::class.java),
+        fnr = getString("fnr"),
+        startdato = getObject("startdato", LocalDate::class.java),
+        type = getString("type"),
+        opprettet = getTimestamp("opprettet").toInstant().atOffset(ZoneOffset.UTC),
+        sendes = getTimestamp("sendes").toInstant().atOffset(ZoneOffset.UTC),
+        avbrutt = getTimestamp("avbrutt")?.toInstant()?.atOffset(ZoneOffset.UTC),
+        sendt = getTimestamp("sendt")?.toInstant()?.atOffset(ZoneOffset.UTC)
+    )

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/PlanlagtMeldingDbModel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/PlanlagtMeldingDbModel.kt
@@ -4,7 +4,9 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
+const val BREV_4_UKER_TYPE = "4UKER"
 const val AKTIVITETSKRAV_8_UKER_TYPE = "8UKER"
+const val BREV_39_UKER_TYPE = "39UKER"
 
 data class PlanlagtMeldingDbModel(
     val id: UUID,

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingServiceTest.kt
@@ -1,0 +1,60 @@
+package no.nav.syfo.aktivermelding
+
+import java.time.OffsetDateTime
+import java.util.UUID
+import no.nav.syfo.aktivermelding.db.AKTIVITETSKRAV_8_UKER_TYPE
+import no.nav.syfo.aktivermelding.db.BREV_39_UKER_TYPE
+import no.nav.syfo.aktivermelding.db.BREV_4_UKER_TYPE
+import no.nav.syfo.testutil.lagPlanlagtMelding
+import org.amshove.kluent.shouldEqual
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object AktiverMeldingServiceTest : Spek({
+    val planlagtMelding4uker = UUID.randomUUID()
+    val planlagtMelding8uker = UUID.randomUUID()
+    val planlagtMelding39uker = UUID.randomUUID()
+
+    describe("Filtrering av meldinger med samme fnr som aktiveres samtidig") {
+        it("Filtrerer bort 8- og 39-ukersmelding") {
+            val planlagteMeldinger = listOf(
+                lagPlanlagtMelding(id = planlagtMelding8uker, type = AKTIVITETSKRAV_8_UKER_TYPE, opprettet = OffsetDateTime.now().minusNanos(20), sendes = OffsetDateTime.now().minusDays(20)),
+                lagPlanlagtMelding(id = planlagtMelding39uker, type = BREV_39_UKER_TYPE, opprettet = OffsetDateTime.now().minusNanos(10), sendes = OffsetDateTime.now().minusDays(10)),
+                lagPlanlagtMelding(id = planlagtMelding4uker, type = BREV_4_UKER_TYPE, opprettet = OffsetDateTime.now().minusNanos(30), sendes = OffsetDateTime.now().minusDays(30))
+            )
+
+            val filtrerteMeldinger = filtrerBortPlanlagteMeldingerForSammeFnr(planlagteMeldinger)
+
+            filtrerteMeldinger.size shouldEqual 1
+            filtrerteMeldinger[0].type shouldEqual BREV_4_UKER_TYPE
+        }
+        it("Filtrerer bort 39-ukersmelding") {
+            val planlagteMeldinger = listOf(
+                lagPlanlagtMelding(id = planlagtMelding8uker, type = AKTIVITETSKRAV_8_UKER_TYPE, opprettet = OffsetDateTime.now().minusNanos(20), sendes = OffsetDateTime.now().minusDays(20)),
+                lagPlanlagtMelding(id = planlagtMelding39uker, type = BREV_39_UKER_TYPE, opprettet = OffsetDateTime.now().minusNanos(10), sendes = OffsetDateTime.now().minusDays(10))
+            )
+
+            val filtrerteMeldinger = filtrerBortPlanlagteMeldingerForSammeFnr(planlagteMeldinger)
+
+            filtrerteMeldinger.size shouldEqual 1
+            filtrerteMeldinger[0].type shouldEqual AKTIVITETSKRAV_8_UKER_TYPE
+        }
+        it("Filtrerer ikke bort meldinger med ulikt fnr") {
+            val planlagteMeldinger = listOf(
+                lagPlanlagtMelding(id = planlagtMelding8uker, fnr = "fnr1", type = AKTIVITETSKRAV_8_UKER_TYPE, sendes = OffsetDateTime.now().minusMinutes(20)),
+                lagPlanlagtMelding(id = planlagtMelding39uker, fnr = "fnr2", type = BREV_39_UKER_TYPE, sendes = OffsetDateTime.now().minusMinutes(10))
+            )
+
+            val filtrerteMeldinger = filtrerBortPlanlagteMeldingerForSammeFnr(planlagteMeldinger)
+
+            filtrerteMeldinger.size shouldEqual 2
+            filtrerteMeldinger[0].fnr shouldEqual "fnr1"
+            filtrerteMeldinger[1].fnr shouldEqual "fnr2"
+        }
+        it("Feiler ikke ved tom liste") {
+            val filtrerteMeldinger = filtrerBortPlanlagteMeldingerForSammeFnr(emptyList())
+
+            filtrerteMeldinger.size shouldEqual 0
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/DbQueriesTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/DbQueriesTest.kt
@@ -1,13 +1,11 @@
 package no.nav.syfo.aktivermelding
 
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
-import no.nav.syfo.aktivermelding.db.AKTIVITETSKRAV_8_UKER_TYPE
-import no.nav.syfo.aktivermelding.db.PlanlagtMeldingDbModel
 import no.nav.syfo.aktivermelding.db.hentPlanlagteMeldingerSomSkalAktiveres
 import no.nav.syfo.testutil.TestDB
 import no.nav.syfo.testutil.dropData
+import no.nav.syfo.testutil.lagPlanlagtMelding
 import no.nav.syfo.testutil.lagrePlanlagtMelding
 import no.nav.syfo.testutil.setUp
 import org.amshove.kluent.shouldEqual
@@ -41,7 +39,7 @@ object DbQueriesTest : Spek({
             val planlagteMeldinger = testDb.hentPlanlagteMeldingerSomSkalAktiveres(OffsetDateTime.now())
 
             planlagteMeldinger.size shouldEqual 1
-            planlagteMeldinger[0] shouldEqual planlagtMeldingSkalSendesId
+            planlagteMeldinger[0].id shouldEqual planlagtMeldingSkalSendesId
         }
         it("Henter ikke UUID for melding som skal aktiveres ennå") {
             testDb.connection.lagrePlanlagtMelding(lagPlanlagtMelding(id = planlagtMeldingSkalSendesId, sendes = OffsetDateTime.now().plusDays(2)))
@@ -52,16 +50,3 @@ object DbQueriesTest : Spek({
         }
     }
 })
-
-fun lagPlanlagtMelding(id: UUID, sendes: OffsetDateTime = OffsetDateTime.now().minusHours(5), sendt: OffsetDateTime? = null, avbrutt: OffsetDateTime? = null): PlanlagtMeldingDbModel {
-    return PlanlagtMeldingDbModel(
-        id = id,
-        fnr = "fnr",
-        startdato = LocalDate.now().minusMonths(2),
-        type = AKTIVITETSKRAV_8_UKER_TYPE,
-        opprettet = OffsetDateTime.now().minusWeeks(7),
-        sendes = sendes,
-        avbrutt = avbrutt,
-        sendt = sendt
-    )
-}

--- a/src/test/kotlin/no/nav/syfo/testutil/Testdata.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/Testdata.kt
@@ -1,0 +1,28 @@
+package no.nav.syfo.testutil
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import no.nav.syfo.aktivermelding.db.AKTIVITETSKRAV_8_UKER_TYPE
+import no.nav.syfo.aktivermelding.db.PlanlagtMeldingDbModel
+
+fun lagPlanlagtMelding(
+    id: UUID,
+    fnr: String = "fnr",
+    type: String = AKTIVITETSKRAV_8_UKER_TYPE,
+    opprettet: OffsetDateTime = OffsetDateTime.now().minusWeeks(7),
+    sendes: OffsetDateTime = OffsetDateTime.now().minusHours(5),
+    sendt: OffsetDateTime? = null,
+    avbrutt: OffsetDateTime? = null
+): PlanlagtMeldingDbModel {
+    return PlanlagtMeldingDbModel(
+        id = id,
+        fnr = fnr,
+        startdato = LocalDate.now().minusMonths(2),
+        type = type,
+        opprettet = opprettet,
+        sendes = sendes,
+        avbrutt = avbrutt,
+        sendt = sendt
+    )
+}


### PR DESCRIPTION
De aller fleste Arena-meldingene som havner på feilkø skyldes at vi forsøker å sende både 4- og 8-ukersmelding for samme fnr og sykeforløp rett etter hverandre. Det liker ikke Arena. 

Denne endringen her gjør at vi kun plukker og aktiverer den meldingen som har det tidligste utsendingstidspunktet hvis vi finner flere meldinger for samme fnr. De andre meldingene for samme fnr vil plukkes opp av neste kjøring. 

Forhåpentligvis vil dette her gjøre at det blir mye mindre som havner på feilkø. 